### PR TITLE
prepended http to url link

### DIFF
--- a/apprenticeships.json
+++ b/apprenticeships.json
@@ -37,7 +37,7 @@
 
   { "name"          : "The Difference Engine",
     "industry"      : "Consulting / Products",
-    "url"           : "www.thedifferenceengine.io",
+    "url"           : "http://www.thedifferenceengine.io",
     "image_url"     : "programs/difference_engine.jpg",
     "cohort_size"   : "28 Apprentices",
     "duration"      : "4 Months",


### PR DESCRIPTION
Link to thedifferenceengine.io was not working. Fixed json value.